### PR TITLE
Fix retain cycle

### DIFF
--- a/Sources/APIManager/Classes/APIRequest.swift
+++ b/Sources/APIManager/Classes/APIRequest.swift
@@ -58,11 +58,7 @@ open class APIRequest<ReturnType: APIReturnable> {
     public typealias Cancellation = () -> Void
 
     // MARK: - Required Properties
-<<<<<<< HEAD
     /// The endpoint for the HTTP Request relative to the baseURL of the `service`.
-=======
-    /// The endpoint for the HTTP Request relative to the baseURL of the service.
->>>>>>> 16427c4a911a57385e0013da1d26565d93ac4773
     open private(set) var endpoint: String
 
     /// The method for the HTTP Request.
@@ -299,7 +295,7 @@ open class APIRequest<ReturnType: APIReturnable> {
 
     /**
      */
-    private var unmanaged: Unmanaged<APIRequest<Service, ReturnType>>? {
+    private var unmanaged: Unmanaged<APIRequest<ReturnType>>? {
         willSet {
             unmanaged?.release()
         }

--- a/Sources/APIManager/Classes/APIRequest.swift
+++ b/Sources/APIManager/Classes/APIRequest.swift
@@ -304,8 +304,3 @@ open class APIRequest<ReturnType: APIReturnable> {
         unmanaged = Unmanaged.passRetained(self)
     }
 }
-
-
-
-
-

--- a/Tests/APIManagerTests/APIManagerTests.swift
+++ b/Tests/APIManagerTests/APIManagerTests.swift
@@ -15,7 +15,10 @@ class APIManagerTests: XCTestCase {
         .onFailure { (error) in
             XCTAssert(false, error.localizedDescription)
             complete.fulfill()
-        }.authorization(nil).perform()
+        }
+        .authorization(nil)
+        .perform()
+        .autoManage()
 
         waitForExpectations(timeout: 5.0, handler: nil)
     }
@@ -34,6 +37,7 @@ class APIManagerTests: XCTestCase {
             complete.fulfill()
         }
         .perform()
+        .autoManage()
 
         waitForExpectations(timeout: 5.0, handler: nil)
     }
@@ -51,6 +55,7 @@ class APIManagerTests: XCTestCase {
             complete.fulfill()
         }
         .perform()
+        .autoManage()
 
         waitForExpectations(timeout: 5.0, handler: nil)
     }
@@ -69,6 +74,7 @@ class APIManagerTests: XCTestCase {
             complete.fulfill()
         }
         .perform()
+        .autoManage()
 
         waitForExpectations(timeout: 5.0, handler: nil)
     }
@@ -87,6 +93,7 @@ class APIManagerTests: XCTestCase {
             complete.fulfill()
         }
         .perform()
+        .autoManage()
 
         waitForExpectations(timeout: 5.0, handler: nil)
     }
@@ -104,6 +111,7 @@ class APIManagerTests: XCTestCase {
             complete.fulfill()
         }
         .perform()
+        .autoManage()
 
         waitForExpectations(timeout: 5.0, handler: nil)
     }
@@ -122,6 +130,7 @@ class APIManagerTests: XCTestCase {
             complete.fulfill()
         }
         .perform()
+        .autoManage()
 
         waitForExpectations(timeout: 5.0, handler: nil)
     }

--- a/Tests/APIManagerTests/TestService.swift
+++ b/Tests/APIManagerTests/TestService.swift
@@ -10,7 +10,7 @@ import Foundation
 import APIManager
 
 class TestService: APIService {
-    
+
     static var baseURL: String = "https://httpbin.org"
 
     static var headers: HTTPHeaders?


### PR DESCRIPTION
Added APIRequest.autoManage() to allow APIManager make sure the APIRequest does not go out of scope